### PR TITLE
fixes #10 - skip merging when user doesnt have kube config does not exist

### DIFF
--- a/cmd/client/cli/commands.go
+++ b/cmd/client/cli/commands.go
@@ -418,7 +418,6 @@ func kubeConfig() *cobra.Command {
 			//set the current cluster context as new context
 			newConfig.CurrentContext = res.ClusterName
 			if !skipMerge {
-				fmt.Println("added")
 				mergo.Merge(kubeConfg, currentKC, mergo.WithOverride)
 			}
 			mergo.Merge(kubeConfg, newConfig, mergo.WithOverride)

--- a/cmd/client/cli/commands.go
+++ b/cmd/client/cli/commands.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	proto "gitlab.com/netbook-devs/spawner-service/proto/netbookdevs/spawnerservice"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 //unmarshalFile read the given file content and umarshal it to given interface
@@ -414,15 +413,13 @@ func kubeConfig() *cobra.Command {
 				log.Fatalf("failed to load the existing kube config : %s\n", err.Error())
 			}
 
-			kubeConfg := clientcmdapi.NewConfig()
 			//set the current cluster context as new context
-			newConfig.CurrentContext = res.ClusterName
 			if !skipMerge {
-				mergo.Merge(kubeConfg, currentKC, mergo.WithOverride)
+				mergo.Merge(newConfig, currentKC, mergo.WithOverride)
 			}
-			mergo.Merge(kubeConfg, newConfig, mergo.WithOverride)
+			newConfig.CurrentContext = res.ClusterName
 
-			err = clientcmd.WriteToFile(*kubeConfg, kubefile)
+			err = clientcmd.WriteToFile(*newConfig, kubefile)
 			if err != nil {
 				log.Fatalf("failed to write kube config : %s\n", err.Error())
 			}


### PR DESCRIPTION
# Description

When generating kubeconfig, spawner fails if there are not existing kube config at ~/.kube/config

Fixes #10 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# why

# How Has This Been Tested?

tested running locally, 
- delete ~/.kube/confg
- run the command

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
